### PR TITLE
Fix broken dependencies for sesame and simmetrics

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -9,13 +9,4 @@
   </parent>
   <artifactId>sthist-api</artifactId>
   <name>sthist-api</name>
-  <url>http://maven.apache.org</url>
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>3.8.1</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
 </project>

--- a/api/src/main/java/gr/demokritos/iit/irss/semagrow/base/range/CircleRange.java
+++ b/api/src/main/java/gr/demokritos/iit/irss/semagrow/base/range/CircleRange.java
@@ -3,7 +3,7 @@ package gr.demokritos.iit.irss.semagrow.base.range;
 import gr.demokritos.iit.irss.semagrow.api.range.Range;
 import gr.demokritos.iit.irss.semagrow.api.range.RangeLength;
 import gr.demokritos.iit.irss.semagrow.api.range.Rangeable;
-import uk.ac.shef.wit.simmetrics.similaritymetrics.JaroWinkler;
+import org.simmetrics.metrics.JaroWinkler;
 
 /**
  * Created by katerina on 20/11/2015.
@@ -78,7 +78,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
 
     @Override
     public boolean includes(String elem) {
-        if ((1.0 - strMetric.getSimilarity(elem, center)) <= radius)
+        if ((1.0 - strMetric.distance(elem, center)) <= radius)
             return true;
 
         return false;
@@ -92,7 +92,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
         if (this.getCenter() == null || this.getCenter().equalsIgnoreCase(""))
             return true;
 
-        double cDist = 1.0 - strMetric.getSimilarity(circleRange.getCenter(), this.center);
+        double cDist = 1.0 - strMetric.distance(circleRange.getCenter(), this.center);
 
         if (cDist + circleRange.getRadius() <= this.radius)
             return true;
@@ -112,7 +112,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
             return true;
 
 
-        double cDist = 1.0 - strMetric.getSimilarity(circleRange.getCenter(), this.center);
+        double cDist = 1.0 - strMetric.distance(circleRange.getCenter(), this.center);
         //double cDist = strMetric.getSimilarity(circleRange.getCenter(), this.center);
 
         if (cDist == 0.0)
@@ -130,7 +130,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
     @Override
     public void expand(String v) {
         if (!this.includes(v)) {
-            double cDist = 1.0 - strMetric.getSimilarity(v, this.center);
+            double cDist = 1.0 - strMetric.distance(v, this.center);
             this.radius = cDist;
         }
         count++;
@@ -144,7 +144,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
             return this;
 
         else {
-            double cDist = 1.0 - strMetric.getSimilarity(circleRange.getCenter(), this.center);
+            double cDist = 1.0 - strMetric.distance(circleRange.getCenter(), this.center);
             return new CircleRange("", Math.max((circleRange.getRadius() + this.radius - cDist) , 0));
         }
     }
@@ -157,7 +157,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
             return new CircleRange("", (circleRange.getRadius() - this.radius));
 
         else {
-            double cDist = 1.0 - strMetric.getSimilarity(circleRange.getCenter(), this.center);
+            double cDist = 1.0 - strMetric.distance(circleRange.getCenter(), this.center);
             return new CircleRange("", ( this.getRadius() - Math.max((circleRange.getRadius() + this.radius - cDist) , 0)) );
         }
     }
@@ -172,7 +172,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
             return circleRange;
 
         else if (this.intersects(circleRange)) {
-            double cDist = 1.0 - strMetric.getSimilarity(circleRange.getCenter(), this.center);
+            double cDist = 1.0 - strMetric.distance(circleRange.getCenter(), this.center);
             if (this.radius > circleRange.getRadius()) {
                 CircleRange c = new CircleRange(this.center, cDist);
                 c.setLength(this.getLength() + circleRange.getLength());
@@ -188,7 +188,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
         }
 
         if (this.radius == 0.0 || circleRange.getRadius() == 0.0) {
-            double cDist = 1.0 - strMetric.getSimilarity(circleRange.getCenter(), this.center);
+            double cDist = 1.0 - strMetric.distance(circleRange.getCenter(), this.center);
 
             if (this.radius == 0.0) {
                 CircleRange c = new CircleRange(circleRange.getCenter(), cDist);
@@ -204,7 +204,7 @@ public class CircleRange implements RangeLength<String>, Rangeable<CircleRange> 
             }
         }
         else {
-            double cDist = 1.0 - strMetric.getSimilarity(circleRange.getCenter(), this.center);
+            double cDist = 1.0 - strMetric.distance(circleRange.getCenter(), this.center);
             CircleRange c = new CircleRange(this.getCenter(), cDist+this.radius);
             c.setLength(this.count + circleRange.getLength());
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,16 +30,9 @@
 	<repositories>
 
         <repository>
-            <id>simmetrics repo</id>
-            <url>http://maven.mse.jhu.edu/m2repository/</url>
-        </repository>
-
-        <repository>
             <id>maven-central</id>
             <url>http://central.maven.org/maven2</url>
         </repository>
-
-
         <repository>
             <id>default-repo</id>
             <name>Default maven repo</name>
@@ -50,18 +43,6 @@
             </snapshots>
         </repository>
 
-
-        <repository>
-            <id>swc-semagrow</id>
-            <name>SWC SemaGrow Repository</name>
-            <url>http://semagrow.semantic-web.at/mvn/</url>
-            <snapshots>
-                <updatePolicy>always</updatePolicy>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-
-
     </repositories>
 
 
@@ -69,9 +50,8 @@
 
       <dependency>
           <groupId>org.openrdf.sesame</groupId>
-          <artifactId>openrdf-sesame</artifactId>
+          <artifactId>sesame-runtime</artifactId>
           <version>${sesame.version}</version>
-          <classifier>onejar</classifier>
       </dependency>
       <dependency>
           <groupId>com.googlecode.json-simple</groupId>
@@ -108,21 +88,15 @@
       </dependency>
 
       <dependency>
-          <groupId>uk.ac.shef.wit</groupId>
-          <artifactId>simmetrics</artifactId>
-          <version>1.6.2</version>
+          <groupId>com.github.mpkorstanje</groupId>
+          <artifactId>simmetrics-core</artifactId>
+          <version>4.1.0</version>
       </dependency>
 
       <dependency>
           <groupId>org.slf4j</groupId>
           <artifactId>slf4j-api</artifactId>
           <version>${slf4j.version}</version>
-      </dependency>
-
-      <dependency>
-          <groupId>uk.ac.shef.wit</groupId>
-          <artifactId>simmetrics</artifactId>
-          <version>1.6.2</version>
       </dependency>
 
   </dependencies>

--- a/stholes-prefix/src/main/java/gr/demokritos/iit/irss/semagrow/stholes/STHolesCircleHistogram.java
+++ b/stholes-prefix/src/main/java/gr/demokritos/iit/irss/semagrow/stholes/STHolesCircleHistogram.java
@@ -7,7 +7,7 @@ import gr.demokritos.iit.irss.semagrow.api.qfr.QueryResult;
 import gr.demokritos.iit.irss.semagrow.base.Stat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import uk.ac.shef.wit.simmetrics.similaritymetrics.JaroWinkler;
+import org.simmetrics.metrics.JaroWinkler;
 
 import java.util.*;
 
@@ -338,7 +338,7 @@ public class STHolesCircleHistogram<R extends Rectangle<R>> extends STHistogramB
         for (STHolesBucket<R> bucketChild : bucket.getChildren()) {
             String subj2 = getSubject(bucketChild.getBox());
 
-            if (jw.getSimilarity(subj1, subj2) == 1.0)
+            if (jw.distance(subj1, subj2) == 1.0)
                 return null;
 
             chCand = getCandidateBuckets(bucketChild, queryBox);
@@ -1130,7 +1130,7 @@ public class STHolesCircleHistogram<R extends Rectangle<R>> extends STHistogramB
         String subj1 = getSubject(mergeBox.getB1().getBox());
         String subj2 = getSubject(mergeBox.getB2().getBox());
 
-        mergeBox.setPenalty((1.0 - jw.getSimilarity(subj1, subj2)) + mergeBox.getPenalty());
+        mergeBox.setPenalty((1.0 - jw.distance(subj1, subj2)) + mergeBox.getPenalty());
 
         return mergeBox;
     }

--- a/stholes-prefix/src/main/java/gr/demokritos/iit/irss/semagrow/stholes/STHolesHistogram.java
+++ b/stholes-prefix/src/main/java/gr/demokritos/iit/irss/semagrow/stholes/STHolesHistogram.java
@@ -4,15 +4,10 @@ import gr.demokritos.iit.irss.semagrow.api.Rectangle;
 import gr.demokritos.iit.irss.semagrow.api.STHistogram;
 import gr.demokritos.iit.irss.semagrow.api.qfr.QueryRecord;
 import gr.demokritos.iit.irss.semagrow.api.qfr.QueryResult;
-import gr.demokritos.iit.irss.semagrow.api.range.Range;
 import gr.demokritos.iit.irss.semagrow.base.Stat;
-import gr.demokritos.iit.irss.semagrow.base.range.PrefixRange;
-import org.openrdf.model.URI;
-import org.openrdf.model.Value;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import sun.misc.Resource;
-import uk.ac.shef.wit.simmetrics.similaritymetrics.JaroWinkler;
+import org.simmetrics.metrics.JaroWinkler;
 
 import java.util.*;
 
@@ -618,8 +613,8 @@ public class STHolesHistogram<R extends Rectangle<R>> extends STHistogramBase<R,
         String subj1 = getSubject(mergeBox.getB1().getBox());
         String subj2 = getSubject(mergeBox.getB2().getBox());
 
-        logger.info("JW similarity : " + (1.0 - jw.getSimilarity(subj1, subj2)));
-        mergeBox.setPenalty((1.0 - jw.getSimilarity(subj1, subj2)) + mergeBox.getPenalty());
+        logger.info("JW similarity : " + (1.0 - jw.distance(subj1, subj2)));
+        mergeBox.setPenalty((1.0 - jw.distance(subj1, subj2)) + mergeBox.getPenalty());
 
         return mergeBox;
     }


### PR DESCRIPTION
The repositories of SWC and mse.jhu.edu had stopped working,
so this patch redirects the resolving of the dependencies to
the maven central. Also, some changes in the namespace imports
are required for this to work.

Note: JaroWinkler.getSimilarity is substituted with JaroWinkler.distance
